### PR TITLE
Make citygen2D.py deterministic

### DIFF
--- a/cityGen2D.py
+++ b/cityGen2D.py
@@ -226,7 +226,7 @@ class Delaunay2D:
         vor_coors = []
         index={}
         # Build a list of coordinates and a index per triangle/region
-        for tidx, (a, b, c) in enumerate(self.triangles):
+        for tidx, (a, b, c) in enumerate(sorted(self.triangles)):
             vor_coors.append(self.circles[(a,b,c)][0])
             # Insert triangle, rotating it so the key is the "last" vertex 
             useVertex[a]+=[(b, c, a)]


### PR DESCRIPTION
We have discovered that different versions of python3 may iterate dictionaries in different orders. Sometimes sorted-by-key, sometimes not. This made cityGen2D.py non deterministic even in presence of the `--randomSeed`argument.

This change ensures that `triangles` dictionary is sorted-by-key iterated, when building Voronoi diagrams.